### PR TITLE
Flickr uploads set to private (Issue #16)

### DIFF
--- a/hosts/flickr.js
+++ b/hosts/flickr.js
@@ -64,7 +64,7 @@ Hosts.flickr = function uploadFlickr(req, uploaded_fn){
     var p = auth({
       auth_token: localStorage.flickr_token, 
       tags: "drag2up",
-      is_public: 1
+      is_public: 0
     });
     p.photo = req;
     xhr.onload = function(){


### PR DESCRIPTION
This should set the default visibility of Flickr uploads to private

Issue #16
